### PR TITLE
feat: add crashloop example

### DIFF
--- a/akp-demo/bootstrap/argocd/01-argocd-apps.yaml
+++ b/akp-demo/bootstrap/argocd/01-argocd-apps.yaml
@@ -92,3 +92,24 @@ spec:
   syncPolicy:
     syncOptions:
     - CreateNamespace=true
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: guestbook-crashloop
+  namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: akp-demo:crashloop
+spec:
+  project: akp-demo
+  source:
+    repoURL: https://github.com/akuity/akp-demo.git
+    targetRevision: HEAD
+    path: crashloop-demo/
+  destination:
+    name: demo
+    namespace: akp-demo
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=true

--- a/akp-demo/bootstrap/kargo/03-promotasks.yaml
+++ b/akp-demo/bootstrap/kargo/03-promotasks.yaml
@@ -17,10 +17,11 @@ spec:
           repoURL: https://github.com/akuity/akp-demo.git
 
 ---
+# This promotion will only sync the application without updating the image
 apiVersion: kargo.akuity.io/v1alpha1
 kind: PromotionTask
 metadata:
-  name: promote-oom
+  name: promote-sync-only
   namespace: akp-demo
 spec:
   steps:

--- a/akp-demo/bootstrap/kargo/04-stages.yaml
+++ b/akp-demo/bootstrap/kargo/04-stages.yaml
@@ -74,4 +74,23 @@ spec:
     spec:
       steps:
       - task:
-          name: promote-oom
+          name: promote-sync-only
+
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: crashloop
+  namespace: akp-demo
+spec:
+  requestedFreight:
+  - origin:
+      kind: Warehouse
+      name: guestbook
+    sources:
+      direct: true
+  promotionTemplate:
+    spec:
+      steps:
+      - task:
+          name: promote-sync-only

--- a/charts/guestbook/values-oom.yaml
+++ b/charts/guestbook/values-oom.yaml
@@ -1,3 +1,0 @@
-env:
-  - name: CONSUME_MEMORY_MB
-    value: "180"

--- a/crashloop-demo/manifest.yaml
+++ b/crashloop-demo/manifest.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crashloop-demo
+spec:
+  minReadySeconds: 10
+  progressDeadlineSeconds: 20
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: crashloop-demo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: crashloop-demo
+    spec:
+      containers:
+        - name: guestbook
+          image: ghcr.io/akuity/guestbook:v0.0.2
+          command:
+          - /app/guestbook
+          args:
+          - --port=30000
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 3000
+            name: http
+            protocol: TCP
+          livenessProbe:
+            failureThreshold: 2
+            httpGet:
+              path: /
+              port: http
+              scheme: HTTP
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000


### PR DESCRIPTION
Example where `--port` argument mismatches with the liveness probe port, causing a CrashLoopBackoff.