### PR TITLE
chore: start crashloop example in degraded state

### DIFF
--- a/akp-demo/bootstrap/kargo/02-freight.yaml
+++ b/akp-demo/bootstrap/kargo/02-freight.yaml
@@ -1,3 +1,5 @@
+# Prepopulates an older Freight version so we can demonstrate going from
+# an older image to a newer one
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Freight
 metadata:
@@ -24,29 +26,3 @@ images:
   digest: sha256:00ca33883ac6d18b7347a2a04d51fcf1e4fd09ef7404252333152543d68fe255
   repoURL: ghcr.io/akuity/guestbook
   tag: v0.0.1
-
----
-apiVersion: kargo.akuity.io/v1alpha1
-kind: Freight
-metadata:
-  labels:
-    kargo.akuity.io/alias: aspiring-woodpecker
-  name: fb6e6fd656f01b8e649257b39023384ca469f70f
-  namespace: akp-demo
-origin:
-  kind: Warehouse
-  name: guestbook
-alias: aspiring-woodpecker
-images:
-- annotations:
-    org.opencontainers.image.created: "2025-07-02T23:11:02.644Z"
-    org.opencontainers.image.description: ""
-    org.opencontainers.image.licenses: ""
-    org.opencontainers.image.revision: 59d3b42c8919c74d9619116c9440c96c54ea32de
-    org.opencontainers.image.source: https://github.com/akuity/guestbook
-    org.opencontainers.image.title: guestbook
-    org.opencontainers.image.url: https://github.com/akuity/guestbook
-    org.opencontainers.image.version: v0.0.2
-  digest: sha256:faae7216af7e9b22e5a1f7961d9c3d89a4206727363b06f6eeb9622b00f7dc19
-  repoURL: ghcr.io/akuity/guestbook
-  tag: v0.0.2

--- a/akp-demo/bootstrap/kargo/05-promotion.yaml
+++ b/akp-demo/bootstrap/kargo/05-promotion.yaml
@@ -10,7 +10,8 @@ spec:
   freight: 4e67f4de17e873b4481de67e7f85244be6ce3009
   stage: dev
   steps:
-  - as: task-1::step-1
+  - uses: argocd-update
+    as: task-1::step-1
     config:
       apps:
       - name: guestbook-${{ ctx.stage }}
@@ -20,4 +21,24 @@ spec:
             - key: image.tag
               value: ${{ imageFrom("ghcr.io/akuity/guestbook").Tag }}
           repoURL: https://github.com/akuity/akp-demo.git
-    uses: argocd-update
+
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Promotion
+metadata:
+  annotations:
+    kargo.akuity.io/create-actor: admin
+    argocd.argoproj.io/sync-wave: "2"
+  name: crashloop.01jzty7jdahg1myrf58mrewtkn.4e67f4d
+  namespace: akp-demo
+spec:
+  freight: 4e67f4de17e873b4481de67e7f85244be6ce3009
+  stage: crashloop
+  steps:
+  - uses: argocd-update
+    as: task-1::step-1
+    config:
+      apps:
+      - name: guestbook-${{ ctx.stage }}
+        sources:
+        - repoURL: https://github.com/akuity/akp-demo.git


### PR DESCRIPTION
This simplifies the crashloop demo by immediately promoting the crashloop app, so that it doesn't have to be done by the user, eliminating about 5 extra manual steps.