### PR TITLE
fix: change create author to expected default

### DIFF
--- a/akp-demo/bootstrap/kargo/05-promotion.yaml
+++ b/akp-demo/bootstrap/kargo/05-promotion.yaml
@@ -2,7 +2,7 @@ apiVersion: kargo.akuity.io/v1alpha1
 kind: Promotion
 metadata:
   annotations:
-    kargo.akuity.io/create-actor: admin
+    kargo.akuity.io/create-actor: kubernetes:system:serviceaccount:kargo:kargo-gitops-sa
     argocd.argoproj.io/sync-wave: "2"
   name: dev.01jz8zrm16tq35vfp9dngxnjz4.4e67f4d
   namespace: akp-demo
@@ -27,7 +27,7 @@ apiVersion: kargo.akuity.io/v1alpha1
 kind: Promotion
 metadata:
   annotations:
-    kargo.akuity.io/create-actor: admin
+    kargo.akuity.io/create-actor: kubernetes:system:serviceaccount:kargo:kargo-gitops-sa
     argocd.argoproj.io/sync-wave: "2"
   name: crashloop.01jzty7jdahg1myrf58mrewtkn.4e67f4d
   namespace: akp-demo


### PR DESCRIPTION
I've followed the Akuity demo and noticed that `akp-demo-bootstrap-kargo` app is out of sync as soon as it is created due to `kargo.akuity.io/create-actor` annotation difference.

<img width="1268" height="523" alt="image" src="https://github.com/user-attachments/assets/70645797-3b06-40c8-a41f-c50e7c4f2113" />
